### PR TITLE
Changed to use "spawn" instead of "exec"

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -10,8 +10,8 @@ module.exports = function(options) {
   }
 
   Image.prototype.convert = function(callback, filename) {    
-    var cmdOption = globalOptions;
-    cmdOptions.concat (util.buildCmdOptions(this.objects[0], filename));
+    var cmdOptions = globalOptions; 
+    cmdOptions = cmdOptions.concat(util.buildCmdOptions(this.objects[0], filename));
 
     var convert = spawn("wkhtmltoimage",cmdOptions); 
     

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,24 +1,65 @@
-var exec = require('child_process').exec;
 var util = require("./util.js");
+var spawn = require('child_process').spawn;
 
 module.exports = function(options) {
+
+  var globalOptions = util.buildOptions (options);
   
-  var globalOptions = util.buildOptions(options);
-  
-  function PDF(document) {
+  function Image(document) {
     this.objects = document ? [document] : [];
   }
-  
-  PDF.prototype.command = "wkhtmltoimage" + util.buildOptions(options).join("");
 
-  PDF.prototype.convert = function(callback) {    
-    exec(util.buildCommand(this), callback);
+  Image.prototype.convert = function(callback, filename) {    
+    var cmdOption = globalOptions;
+    cmdOptions.concat (util.buildCmdOptions(this.objects[0], filename));
+
+    var convert = spawn("wkhtmltoimage",cmdOptions); 
+    
+    //take care of direct stdin html
+    if (this.objects[0].html) {
+      var inputHTML = spawn ("echo",this.objects[0].html);
+      inputHTML.stdout.on('data', function (data) {
+          convert.stdin.write(data);
+      });
+      inputHTML.on ('exit', function () {
+          convert.stdin.end();
+      });
+    }
+
+    var image = [];
+    var err;
+
+    convert.stdout.on('data', function (data) {
+        image.push(data);
+    });
+
+    convert.stderr.on('data', function (data) {
+        err += data;
+    });
+
+    convert.on ('exit', function (code) {
+        if (code) {
+          console.log ('child process exited with code ' + code);
+        } else if (!filename) {
+          //combine the buffers
+          var size = 0;
+          for (var i=0; i < image.length; ++i) {
+            size+= image[0].length;
+          }
+          var combinedBuffer = new Buffer (size);
+          var pos = 0;
+          for (var i=0; i < image.length; ++i) {
+            image[i].copy(combinedBuffer, pos, 0, image[i].length);
+            pos += image[i].length;
+          }
+
+          callback (err, combinedBuffer);
+        } else {
+          callback (err);
+        }
+    });
   }
   
-  PDF.prototype.convertAs = function(filename, callback) {
-    exec(util.buildCommand(this, filename), callback);
-  }
-  
-  return PDF;
+  return Image;
 
 };

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
 
   PDF.prototype.convert = function(callback, filename) {    
     var cmdOption = globalOptions;
-    cmdOptions.concat (util.buildCmdOptions(this.objects[0], filename));
+    cmdOptions = cmdOptions.concat (util.buildCmdOptions(this.objects[0], filename));
 
     var convert = spawn("wkhtmltopdf",cmdOptions); 
     

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,30 +1,63 @@
-var exec = require('child_process').exec;
 var util = require("./util.js");
+var spawn = require('child_process').spawn;
 
 module.exports = function(options) {
-  
-  var globalOptions = util.buildOptions(options);
+
+  var globalOptions = util.buildOptions (options);
   
   function PDF(document) {
     this.objects = document ? [document] : [];
   }
-  
-  PDF.prototype.command = "wkhtmltopdf" + util.buildOptions(options).join("");
 
-  /**
-  * { url: string, file: string, html: string, options: object }
-  */
-  PDF.prototype.add = function(options) {
-    this.objects.push(options);
-    return this;
-  }
+  PDF.prototype.convert = function(callback, filename) {    
+    var cmdOption = globalOptions;
+    cmdOptions.concat (util.buildCmdOptions(this.objects[0], filename));
 
-  PDF.prototype.convert = function(callback) {    
-    exec(util.buildCommand(this), callback);
-  }
-  
-  PDF.prototype.convertAs = function(filename, callback) {
-    exec(util.buildCommand(this, filename), callback);
+    var convert = spawn("wkhtmltopdf",cmdOptions); 
+    
+    //take care of direct stdin html
+    if (this.objects[0].html) {
+      var inputHTML = spawn ("echo",this.objects[0].html);
+      inputHTML.stdout.on('data', function (data) {
+          convert.stdin.write(data);
+      });
+      inputHTML.on ('exit', function () {
+          convert.stdin.end();
+      });
+    }
+
+    var image = [];
+    var err;
+
+    convert.stdout.on('data', function (data) {
+        image.push(data);
+    });
+
+    convert.stderr.on('data', function (data) {
+        err += data;
+    });
+
+    convert.on ('exit', function (code) {
+        if (code) {
+          console.log ('child process exited with code ' + code);
+        } else if (!filename) {
+          //combine the buffers
+          var size = 0;
+          for (var i=0; i < image.length; ++i) {
+            size+= image[0].length;
+          }
+          var combinedBuffer = new Buffer (size);
+          var pos = 0;
+          for (var i=0; i < image.length; ++i) {
+            image[i].copy(combinedBuffer, pos, 0, image[i].length);
+            pos += image[i].length;
+          }
+
+          callback (err, combinedBuffer);
+        } else {
+          callback (err);
+        }
+    });
   }
   
   return PDF;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,33 +1,35 @@
-
-
 var buildOptions = module.exports.buildOptions = function(options) {
   var commandOptions = [];
   for (name in options) {
     if (options.hasOwnProperty(name)) {
-      commandOptions = commandOptions.concat(" ", name.length == 1 ? "-" : "--", name, " ", options[name]);
+      commandOptions.push(name);
     }
   }
   return commandOptions;
 };
 
-module.exports.buildCommand = function(doc, filename) {
-  var command = [doc.command];
-  var stdin = null;
-  
-  doc.objects.forEach(function(object) {
-    command = command.concat(" ", object.page || "");
-    if (object.html) {
-      stdin = object.html;
-      command = command.concat("-");
-    } else {
-      command = command.concat(object.filename || object.url);
-    }
-    command = command.concat(buildOptions(object.options));
-  });
-  command = command.concat(" ", filename || "-");
-  if (stdin) {
-    command = ["echo '", stdin, "' | "].concat(command);
+module.exports.buildCmdOptions = function (objects, filename) {
+  //wkhtml options
+  var cmdOptions = [];
+  if (objects.options) {
+    cmdOptions = buildOptions(objects.options);
   }
-  
-  return command.join("");
-}
+
+  //input source
+  if (objects.html) {
+    cmdOptions.push('-');
+  } else if (objects.filename) {
+    cmdOptions.push(objects.filename);
+  } else {
+    cmdOptions.push(objects.url);
+  }
+
+  //output
+  if (filename) {
+    cmdOptions.push(filename);
+  } else {
+    cmdOptions.push('-');
+  }
+    
+  return cmdOptions;
+};


### PR DESCRIPTION
Also, unified functionality somewhat along the lines that you proposed,
 so that everything uses the single function "convert" instead of having 
"convert" and "convertAs". Now, if no filename is given to have the 
command save locally, the function includes the data in a buffer to the 
callback function for the user to do with as they please.

I haven't tested it extensively, but it seemed to work on my example server.
If you want to have the unified interface different than the one I propose here, by all means go ahead.
